### PR TITLE
Pass $app through to code ref

### DIFF
--- a/t/one_crontab.t
+++ b/t/one_crontab.t
@@ -11,10 +11,11 @@ $ENV{MOJO_MODE} = 'test';
 my %local_tstamps;
 
 my $last_epoch;
+my $app;
 
 plugin Cron => (
   '*/10 15 * * *' => sub {
-    $last_epoch = shift;
+    ($last_epoch, $app) = @_;
     $local_tstamps{fmt_time(localtime)}++;
     Mojo::IOLoop->stop;
   }
@@ -41,6 +42,8 @@ is \%local_tstamps,
   "$lday 15:50" => 1,
   },         # no more because hour is always 15 local
   'exact tstamps';
+ok $app, 'is app passed?';
+is ref($app), 'Mojolicious::Lite', 'is app correct type?';
 
 # check that new $epock parameter is available on callback
 ok defined $last_epoch && $last_epoch =~ /^\d{10}$/, "got epoch on callback";


### PR DESCRIPTION
Hi, I want to pass the Mojolicious app through to the CRON code ref. 

We declare our plugin code in a different module than our application code, and we need to access our helpers in our CRON jobs, so this change would be very welcome. Thanks!